### PR TITLE
Add `idle_cycles_burned_per_day` to status

### DIFF
--- a/src/blackhole.mo
+++ b/src/blackhole.mo
@@ -14,6 +14,7 @@ actor {
      cycles : Nat;
      settings : definite_canister_settings;
      module_hash : ?[Nat8];
+     idle_cycles_burned_per_day : Nat;
   };
 
   public type IC = actor {


### PR DESCRIPTION
Add `idle_cycles_burned_per_day` field supported from [v0.18.5](https://internetcomputer.org/docs/current/references/ic-interface-spec#0_18_5)