### PR TITLE
Add pinned reproducible build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ CANISTERS=blackhole
 OBJ=$(CANISTERS:%=dist/%.wasm)
 OBJ_OPT=$(CANISTERS:%=dist/%-opt.wasm)
 IDL=$(CANISTERS:%=dist/%.did)
+NIXPKGS_REV=022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf
+NIXPKGS_SHA256=12q00nbd7fb812zchbcnmdg3pw45qhxm74hgpjmshc2dfmgkjh4n
 
 build: $(OBJ) $(IDL) $(OBJ_OPT)
 
@@ -23,4 +25,7 @@ dist/%.did: src/%.mo | dist
 dfx.json:
 	@echo '{"canisters":{"blackhole":{"type":"custom","candid":"dist/blackhole.did","wasm":"dist/blackhole-opt.wasm","build":""}}}' > $@
 
-.PHONY: build clean really-clean
+repro-build:
+	@nix-build --no-out-link --arg pkgs 'import (builtins.fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/$(NIXPKGS_REV).tar.gz"; sha256 = "$(NIXPKGS_SHA256)"; }) {}'
+
+.PHONY: build clean really-clean repro-build

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To do this, we can verify hash of Wasm binary from three sources: built by githu
 $ curl -Ls https://github.com/ninegua/ic-blackhole/releases/download/0.0.0/blackhole-opt.wasm|sha256sum
 210cf941e5ca77daac314a91517483ac171264527e3d0d713b92bb95239d7de0  -
 
-$ cat $(nix-build 2>/dev/null)/bin/blackhole-opt.wasm |sha256sum
+$ cat "$(make repro-build)"/bin/blackhole-opt.wasm | sha256sum
 210cf941e5ca77daac314a91517483ac171264527e3d0d713b92bb95239d7de0  -
 
 $ make dfx.json && dfx canister --network=ic --no-wallet info $(cat canister_ids.json|jq -r '.blackhole.ic')


### PR DESCRIPTION
Closes #3 

## Summary

This adds a small pinned reproducible build path for `ic-blackhole`.

## Changes

- add a `repro-build` Makefile target
- pin the nixpkgs revision and tarball hash used for the reproducible build
- use `--no-out-link` to avoid creating a `result` symlink in the source tree
- update the README reproducibility command to use `make repro-build`

## Verification

Verified locally that:

```bash
cat "$(make repro-build)"/bin/blackhole-opt.wasm | sha256sum
```
produces:

210cf941e5ca77daac314a91517483ac171264527e3d0d713b92bb95239d7de0  -

It does not produce this hash without pinning the nixpkgs revision